### PR TITLE
[014] Add Season Styling on League Show

### DIFF
--- a/app/assets/stylesheets/leagues.scss
+++ b/app/assets/stylesheets/leagues.scss
@@ -9,6 +9,6 @@ a.list-group-item.league-info {
   cursor: pointer;
 }
 
-tr.league-show__seasons-table.active-season {
-  background-color: #dc3545 !important;
+tr.league-show__seasons-table.active-season, tr.league-show__seasons-table.active-season:hover {
+  color: #d9534f;
 }

--- a/app/assets/stylesheets/leagues.scss
+++ b/app/assets/stylesheets/leagues.scss
@@ -8,3 +8,7 @@ a.list-group-item.league-info {
 .league-show__seasons-table {
   cursor: pointer;
 }
+
+tr.league-show__seasons-table.active-season {
+  background-color: #dc3545 !important;
+}

--- a/app/decorators/season_decorator.rb
+++ b/app/decorators/season_decorator.rb
@@ -1,7 +1,11 @@
 class SeasonDecorator < ApplicationDecorator
   delegate_all
 
-  def active_class
+  def active_season_class
+    "active-season" if season.active_season?
+  end
+
+  def counted_class
     season.count_in_standings? ? 'active' : 'inactive'
   end
 
@@ -9,7 +13,7 @@ class SeasonDecorator < ApplicationDecorator
     season.completed ? uncomplete_button : complete_button
   end
 
-  def inactive_class
+  def uncounted_class
     !season.count_in_standings? ? 'active' : 'inactive'
   end
 

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -33,7 +33,9 @@ class Season < ApplicationRecord
   end
 
   def number_in_order
-    league.seasons.index(self) + 1
+    number = league.seasons.index(self) + 1
+    return "#{number}*" if active_season
+    number
   end
 
   def uncompleted!

--- a/app/views/leagues/_season_cell.html.erb
+++ b/app/views/leagues/_season_cell.html.erb
@@ -1,0 +1,7 @@
+<tr class="league-show__seasons-table <%= season.active_season_class %>" data-link="<%= season_path(season) %>">
+  <td><%= season.number_in_order %></td>
+  <td><%= ["Mark", "Mike", "Tyler", "Marshall"].shuffle.pop %></td>
+  <td>September 1, 2019</td>
+  <td>N/A</td>
+  <td><%= [24, 29, 67].shuffle.pop %></td>
+</tr>

--- a/app/views/leagues/show.html.erb
+++ b/app/views/leagues/show.html.erb
@@ -133,15 +133,7 @@
               </tr>
             </thead>
             <tbody>
-              <% @league.seasons.decorate.each do |season| %>
-                <tr class="league-show__seasons-table" data-link="<%= season_path(season) %>">
-                  <td><%= season.number_in_order %></td>
-                  <td><%= ["Mark", "Mike", "Tyler", "Marshall"].shuffle.pop %></td>
-                  <td>September 1, 2019</td>
-                  <td>N/A</td>
-                  <td><%= [24, 29, 67].shuffle.pop %></td>
-                </tr>
-              <% end %>
+              <%= render partial: 'season_cell', collection: @league.seasons.decorate, as: :season %>
             </tbody>
           </table>
         </div>

--- a/app/views/leagues/show.html.erb
+++ b/app/views/leagues/show.html.erb
@@ -133,7 +133,20 @@
               </tr>
             </thead>
             <tbody>
-              <%= render partial: 'season_cell', collection: @league.seasons.decorate, as: :season %>
+              <% if @league.seasons.any? %>
+                <%=  render partial: 'season_cell', collection: @league.seasons.decorate, as: :season %>
+                <tr>
+                  <td colspan="5">
+                    <small class="muted-text">*Active Season</small>
+                  </td>
+                </tr>
+              <% else %>
+                <tr>
+                  <td colspan="5">
+                    <small class="muted-text">You have no seasons, create one!</small>
+                  </td>
+                </tr>
+              <% end %>
             </tbody>
           </table>
         </div>

--- a/app/views/seasons/show.html.erb
+++ b/app/views/seasons/show.html.erb
@@ -6,8 +6,8 @@
       <div class="count-buttons">
         <label for="something">Count in Overall Standings</label>
         <div class="btn-group" role="group" aria-label="Basic example">
-          <%= link_to "On", season_count_path(@season), method: :post, id: 'on-button', class: "btn btn-outline-secondary #{@season.active_class}" %>
-          <%= link_to "Off", season_uncount_path(@season), method: :post, id: 'off-button', class: "btn btn-outline-secondary #{@season.inactive_class}" %>
+          <%= link_to "On", season_count_path(@season), method: :post, id: 'on-button', class: "btn btn-outline-secondary #{@season.counted_class}" %>
+          <%= link_to "Off", season_uncount_path(@season), method: :post, id: 'off-button', class: "btn btn-outline-secondary #{@season.uncounted_class}" %>
         </div>
       </div>
     <% end %>

--- a/spec/requests/leagues_controller_request_spec.rb
+++ b/spec/requests/leagues_controller_request_spec.rb
@@ -216,4 +216,26 @@ describe LeaguesController, type: :request do
       end
     end
   end
+
+  describe 'DELETE#destroy' do
+    let(:public_league) { true }
+    let(:membership) { create(:membership, league: league, role: 1) }
+    let(:user) { membership.user }
+
+    subject(:delete_destroy) { delete league_path(league) }
+
+    before { sign_in(user) }
+
+    it 'deletes a league' do
+      expect {
+        delete_destroy
+      }.to change(League, :count).by(-1)
+    end
+
+    it 'has 302 status' do
+      delete_destroy
+
+      expect(response).to have_http_status(302)
+    end
+  end
 end

--- a/spec/requests/seasons_controller_request_spec.rb
+++ b/spec/requests/seasons_controller_request_spec.rb
@@ -169,6 +169,8 @@ describe SeasonsController, type: :request do
     end
   end
 
+  pending 'POST#count'
+
   describe 'POST#deactivate' do
     let(:role) { 1 }
 
@@ -240,4 +242,6 @@ describe SeasonsController, type: :request do
       expect(response).to have_http_status(302)
     end
   end
+
+  pending 'POST#uncount'
 end

--- a/spec/requests/seasons_controller_request_spec.rb
+++ b/spec/requests/seasons_controller_request_spec.rb
@@ -169,7 +169,45 @@ describe SeasonsController, type: :request do
     end
   end
 
-  pending 'POST#count'
+  describe 'POST#count' do
+    let(:role) { 1 }
+
+    subject(:post_count) { post season_count_path(season) }
+
+    before { login_as(user) }
+
+    describe 'when count_in_standings is false' do
+      before { season.uncount! }
+
+      it 'changes count_in_standings to true' do
+        expect {
+          post_count; season.reload
+        }.to change{ season.count_in_standings }.to(true)
+      end
+
+      it 'has 302 status' do
+        post_count
+
+        expect(response).to have_http_status(302)
+      end
+    end
+
+    describe 'when count_in_standings is true' do
+      before { season.count! }
+
+      it 'does not change count_in_standings from true' do
+        expect {
+          post_count; season.reload
+        }.not_to change { season.count_in_standings }.from(true)
+      end
+
+      it 'has 302 status' do
+        post_count
+
+        expect(response).to have_http_status(302)
+      end
+    end
+  end
 
   describe 'POST#deactivate' do
     let(:role) { 1 }
@@ -243,5 +281,43 @@ describe SeasonsController, type: :request do
     end
   end
 
-  pending 'POST#uncount'
+  describe 'POST#uncount' do
+    let(:role) { 1 }
+
+    subject(:post_uncount) { post season_uncount_path(season) }
+
+    before { login_as(user) }
+
+    describe 'when count_in_standings is false' do
+      before { season.uncount! }
+
+      it 'does not changes count_in_standings from false' do
+        expect {
+          post_uncount; season.reload
+        }.not_to change{ season.count_in_standings }.from(false)
+      end
+
+      it 'has 302 status' do
+        post_uncount
+
+        expect(response).to have_http_status(302)
+      end
+    end
+
+    describe 'when count_in_standings is true' do
+      before { season.count! }
+
+      it 'changes count_in_standings to false' do
+        expect {
+          post_uncount; season.reload
+        }.to change { season.count_in_standings }.to(false)
+      end
+
+      it 'has 302 status' do
+        post_uncount
+
+        expect(response).to have_http_status(302)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds styling on league#show for the active_season.
It also extracts the season table row on league#show page to its own
partial. This page is going to get big from all of the data being
rendered on it and staying proactive with partials would be a great
approach.