### PR TITLE
Add net earnings as a standing metric on a season

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-20
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
@@ -324,4 +325,4 @@ RUBY VERSION
    ruby 2.6.4p104
 
 BUNDLED WITH
-   2.1.4
+   2.2.1

--- a/app/decorators/player_decorator.rb
+++ b/app/decorators/player_decorator.rb
@@ -17,8 +17,14 @@ class PlayerDecorator < ApplicationDecorator
   def user_display_name(current_user=nil)
     user&.decorate&.display_name(current_user)
   end
+
   def user_full_name
     user&.decorate&.full_name
+  end
+
+  def payout_by_season(season)
+    net_earnings = player.net_earnings_by_season(season)
+    h.number_to_currency(net_earnings, precision: 2)
   end
 
   def place(index)

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -1,6 +1,7 @@
 class Season < ApplicationRecord
   include Settable
 
+  enum scoring_system: { points: 0, net_earnings: 1 }
   after_create :add_all_settings
   
   self.implicit_order_column = 'created_at'

--- a/app/views/leagues/show.html.erb
+++ b/app/views/leagues/show.html.erb
@@ -43,7 +43,7 @@
           </div>
         </div>
         <div class="league-show__overview-standings mt-4">
-          <%= render partial: 'shared/standings_table' %>
+          <%= render partial: 'shared/standings_table', locals: { net_earnings: false } %>
         </div>
         <div class="league-show__overview-games mt-4">
           <%= render partial: 'shared/games_table', locals: { games: @league.games_in_reverse_date_order(12) } %>

--- a/app/views/seasons/show.html.erb
+++ b/app/views/seasons/show.html.erb
@@ -49,7 +49,7 @@
           </div>
         </div>
         <div class="season-show__overview-standings mt-4">
-          <%= render partial: 'shared/standings_table' %>
+          <%= render partial: 'shared/standings_table', locals: { net_earnings: true } %>
         </div>
         <div class="league-show__overview-games mt-4">
           <%= render partial: 'shared/games_table', locals: { games: @season.games_in_reverse_date_order(12) } %>

--- a/app/views/shared/_standings_table.html.erb
+++ b/app/views/shared/_standings_table.html.erb
@@ -4,8 +4,10 @@
     <tr>
       <th scope="col">#</th>
       <th scope="col" class="full-width-cell">Player</th>
+      <% if net_earnings %>
+        <th scope="col">Net Earnings</th>
+      <% end %>
       <th scope="col">Points</th>
-      <!-- //<th scope="col">Winnings</th> //-->
       <th scope="col">Games</th>
     </tr>
   </thead>
@@ -21,8 +23,10 @@
         <tr class="standing <%= standing.place_class(index) %>">
           <th scope="row"><%= standing.place(index) %></th>
           <td><%= link_to standing.user_display_name(current_user), user_stats_path(standing.user_id) %></td>
+          <% if net_earnings %>
+            <td><%= standing.payout_by_season(@season) %></td>
+          <% end %>
           <td><%= number_with_precision(standing.cumulative_score, precision: 3) %></td>
-          <!-- // <td></td>//-->
           <td><%= standing.total_games_played_by_object(@league || @season) %></td>
         </tr>
       <% end %>

--- a/app/views/shared/_standings_table.html.erb
+++ b/app/views/shared/_standings_table.html.erb
@@ -7,7 +7,9 @@
       <% if net_earnings %>
         <th scope="col">Net Earnings</th>
       <% end %>
-      <th scope="col">Points</th>
+      <% unless net_earnings %>
+        <th scope="col">Points</th>
+      <% end %>
       <th scope="col">Games</th>
     </tr>
   </thead>
@@ -26,7 +28,9 @@
           <% if net_earnings %>
             <td><%= standing.payout_by_season(@season) %></td>
           <% end %>
-          <td><%= number_with_precision(standing.cumulative_score, precision: 3) %></td>
+          <% if standing.respond_to?(:cumulative_score) %>
+            <td><%= number_with_precision(standing.cumulative_score, precision: 3) %></td>
+          <% end %>
           <td><%= standing.total_games_played_by_object(@league || @season) %></td>
         </tr>
       <% end %>

--- a/db/migrate/20210102230151_add_scoring_system_to_seasons.rb
+++ b/db/migrate/20210102230151_add_scoring_system_to_seasons.rb
@@ -1,0 +1,5 @@
+class AddScoringSystemToSeasons < ActiveRecord::Migration[6.0]
+  def change
+    add_column :seasons, :scoring_system, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_17_014543) do
+ActiveRecord::Schema.define(version: 2021_01_02_230151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 2020_10_17_014543) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "count_in_standings", default: true
+    t.integer "scoring_system", default: 0
     t.index ["league_id"], name: "index_seasons_on_league_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,61 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+Game.destroy_all
+Season.destroy_all
+League.destroy_all
+Membership.destroy_all
+User.destroy_all
+puts "##### YOLO! #####"
+
+
+admin_user = User.find_or_create_by(first_name: "Mark", last_name: "Miranda", email: "notmarkmiranda@gmail.com")
+admin_user.password = "password"
+admin_user.save
+
+league = League.find_or_create_by(name: "Super Duper")
+league.location = "Zoom"
+league.public_league = true
+league.save
+
+user_count = User.count
+users = user_count == 11 ? User.all : FactoryBot.create_list(:user, 11 - user_count)
+
+admin_membership = Membership.find_or_create_by(user: admin_user, league: league, role: 1)
+
+puts "##### USERS #####"
+
+memberships = users.map do |user|
+  membership = Membership.find_or_initialize_by(user: user, league: league)
+  membership.role = 0 if membership.new_record?
+  membership.save
+  puts "#{user.email} added to #{league.name} league."
+end
+
+season = league.seasons.last
+
+dates = [*1..12].map do |n|
+  Date.new(2020, n, n)
+end
+
+games = dates.map do |date|
+  season.games.create!(
+    completed: false,
+    buy_in: rand(15..150),
+    add_ons: true,
+    address: "123 Fake Street, Anyplace, Colorado",
+    estimated_players_count: rand(2..50),
+    date: date,
+    payout_schedule: { "first" => "50", "second" => "30", "third" => "20" }
+  )
+end
+
+puts "##### GAMES ######"
+games.each do |game|
+  u_array = league.memberships.map(&:user).shuffle.shuffle
+  u_array.each_with_index do |user, i|
+    game.players.create!(finishing_order: (i + 1), user: user, additional_expense: [0, game.buy_in, game.buy_in * 2].sample)
+  end
+  GameCompleter.new(game, 'complete').save
+  puts "Game on #{game.decorate.formatted_short_month_full_date} completed."
+end
+
+season.update(completed: true)
+puts "##### DONE! #####"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,6 @@ Membership.destroy_all
 User.destroy_all
 puts "##### YOLO! #####"
 
-
 admin_user = User.find_or_create_by(first_name: "Mark", last_name: "Miranda", email: "notmarkmiranda@gmail.com")
 admin_user.password = "password"
 admin_user.save

--- a/spec/decorators/player_decorator_spec.rb
+++ b/spec/decorators/player_decorator_spec.rb
@@ -1,4 +1,38 @@
 require 'rails_helper'
 
-describe PlayerDecorator do
+describe PlayerDecorator, type: :decorator do
+  let(:decorated_player) { create(:player).decorate }
+  let(:season) { decorated_player.player.game.season } 
+
+  describe "#payout_by_season" do
+    subject(:show_payout) { decorated_player.payout_by_season(season) }
+    
+    before do
+      allow(decorated_player.player).to receive(:net_earnings_by_season).with(season).and_return(payout)
+    end
+
+    describe "for zero amounts" do
+      let(:payout) { 0 }
+      
+      it "returns $0" do
+        expect(show_payout).to eq("$0.00")
+      end
+    end
+
+    describe "for negative amounts" do
+      let(:payout) { -154.75 }
+      
+      it  "returns -$154.75" do
+        expect(show_payout).to eq("-$154.75")
+      end
+    end
+    
+    describe "for positive amounts" do
+      let(:payout) { 20 }
+      
+      it "returns $20" do
+        expect(show_payout).to eq("$20.00")
+      end
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,9 +1,10 @@
 FactoryBot.define do
+  extensions = ["com", "net", "co", "email", "fr", "xyz"]
   factory :user do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     sequence :email do |n|
-      "test#{n}@example.com"
+      "#{first_name}_U#{last_name}#{rand(100..999)}@#{last_name}#{rand(100..999)}.#{extensions.shuffle.pop}"
     end
     password { "password" }
   end

--- a/spec/features/seasons/season_has_net_earnings_spec.rb
+++ b/spec/features/seasons/season_has_net_earnings_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe "Season has net earnings", type: :feature do
+  describe "For a season with a completed game" do
+    let(:game) { create(:game_with_players, buy_in: 100) }
+    let(:season) { game.season }
+    let(:user) { game.players.last.user }
+
+    before do 
+      login_as(user, scope: :user)
+    end
+
+    it "shows net earnings on a season show" do
+      visit season_path(season)
+
+      expect(page).to have_content("$150.00")
+      expect(page).to have_content("$50.00")
+      expect(page).to have_content("$0.00")
+    end
+  end
+end

--- a/spec/features/seasons/season_ranks_by_net_earnings_spec.rb
+++ b/spec/features/seasons/season_ranks_by_net_earnings_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "A season will rank users by net earnings", type: :feature do
+  let(:game) { create(:game, completed: true) }
+  let(:season) { game.season }
+  let(:league) { season.league }
+  let(:memberships) { create_list(:membership, 2, league: league) }
+  let(:user1) { memberships[0].user }
+  let(:user2) { memberships[1].user }
+  let!(:player1) { create(:player, game: game, finishing_place: 2, payout: 100, score: 10).decorate }
+  let!(:player2) { create(:player, game: game, finishing_place: 1, payout: 10, score: 100).decorate }
+
+  before do 
+    season.update(scoring_system: 1)
+    login_as(user1, scope: :user)
+  end
+
+  it "ranks users by net earnings" do
+    visit season_path(season)
+
+    within("tr.standing.one") do
+      expect(page).to have_content(player1.user_full_name)
+    end
+  end
+end

--- a/spec/lib/standings/standings_compiler_spec.rb
+++ b/spec/lib/standings/standings_compiler_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe Standings::StandingsCompiler do
+  let(:limit) { 99 }
+  subject { described_class.standings(object, limit) }
+
+  describe "when the object is a league"
+
+  describe "when the object is a season" do
+    let(:game) { create(:game_with_players) }
+    let(:object) { game.season }
+    let(:standings) { subject }
+
+    describe "when the season's scoring system is by points" do
+      before { object.points! }
+
+      it "returns players in descending order by points" do
+        expect(standings.first.cumulative_score).to be > standings.last.cumulative_score
+      end
+    end
+
+    describe "when the season's scoring system is by net earnings" do
+      let(:first_place) { game.players.find_by(finishing_place: 1) }
+      let(:second_place) { game.players.find_by(finishing_place: 2) }
+
+      before do
+        first_place.update(additional_expense: 130)
+        GameCompleter.new(game, 'complete').save
+        first_place.update(score: 100)
+        first_place.reload; second_place.reload
+        object.net_earnings!
+      end
+
+      let(:first_place_index) { standings.pluck(:user_id).index(first_place.user_id) }
+      let(:second_place_index) { standings.pluck(:user_id).index(second_place.user_id) }
+      
+      it do
+        expect(first_place_index).to be > second_place_index
+      end
+    end
+  end
+end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -47,5 +47,18 @@ describe Player, type: :model do
         }.to change { player.score }.to(15.811388300841896)
       end
     end
+
+    describe '#net_earnings_by_season' do
+      subject(:player_net_earnings) { player1.net_earnings_by_season(season) }
+      let(:game) { create(:game_with_players) }
+      let(:season) { game.season }
+      let(:player1) { game.players.in_place_order.first }
+
+      before { player1.update(additional_expense: 37)}
+
+      it 'returns net earnings for a player by season' do
+        expect(player_net_earnings).to eq(113)
+      end
+    end
   end
 end

--- a/spec/models/season_spec.rb
+++ b/spec/models/season_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
 describe Season, type: :model do
-  describe 'validations'
+  describe 'validations' do
+    let(:scoring_enums) { { points: 0, net_earnings: 1 } }
+
+    it { should define_enum_for(:scoring_system).with_values(scoring_enums) }
+  end
 
   describe 'relationships' do
     it { should belong_to :league }


### PR DESCRIPTION
# Ticket

#247 

# Problem
Seasons are currently only score able by point totals.

# Solution
This will add net earnings as statistic on a season. As well as allow seasons to be toggle-able to be scored by net earnings.
